### PR TITLE
Removing the exception that gets raised if a video directory is not f…

### DIFF
--- a/cadica_data_set/cadica_data_set.py
+++ b/cadica_data_set/cadica_data_set.py
@@ -81,8 +81,6 @@ class CadicaDataSet:
                                         image_paths_key = os.path.join(patient_dir, video_dir)
                                         self.lesioned_image_paths_dict[image_paths_key] = selected_image_frame_file_paths
                                         self.lesioned_images_set.update(selected_image_frame_file_paths)
-                                    else:
-                                        raise CadicaDataSetError.video_dirs_not_found()
                             if nonlesion_video_dir_paths:
                                 for nonlesion_video_dir_path in nonlesion_video_dir_paths:
                                     if os.path.isdir(nonlesion_video_dir_path):
@@ -93,8 +91,6 @@ class CadicaDataSet:
                                         image_paths_key = os.path.join(patient_dir, video_dir)
                                         self.nonlesioned_image_paths_dict[image_paths_key] = selected_image_frame_file_paths
                                         self.nonlesioned_images_set.update(selected_image_frame_file_paths)
-                                    else:
-                                        raise CadicaDataSetError.video_dirs_not_found()
                         else:
                             raise CadicaDataSetError.videos_txt_files_not_found()
                     else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="cadica_data_set",
-    version="1.0.2",
+    version="1.0.3",
     packages=find_packages(),
     install_requires=[],
     python_requires=">=3.6",

--- a/tests/test_cadica_data_set.py
+++ b/tests/test_cadica_data_set.py
@@ -80,9 +80,3 @@ def test_load_method_indexes_correctly_for_missing_patient_data():
     assert len(cadica_data_set.nonlesioned_image_paths_dict) == 0, "load() API failed, no image paths should be indexed because there is NO patient data."
     assert len(cadica_data_set.lesioned_images_set) == 0, "load() API failed, no image paths should be indexed because there is NO patient data."
     assert len(cadica_data_set.nonlesioned_images_set) == 0, "load() API failed, no image paths should be indexed because there is NO patient data."
-
-def test_load_method_raises_exception_for_missing_video_data():
-    with pytest.raises(FileNotFoundError) as exception_info:
-        cadica_data_set = CadicaDataSet(INVALID_CADICA_TEST_DATA_MISSING_VIDEO_DIRS_ROOT_PATH)
-        cadica_data_set.load()
-    assert str(exception_info.value) == "The video directories containing labeled images for each patient weren't found. Please ensure you did not modify the original cadica data set file structure."


### PR DESCRIPTION
…ound when indexing the data set. This exception is too restrictive and makes it impossible to manually create test sets or manipulate the data set data in anyway. We have enough exceptions for the critical files, removing this one is fine.